### PR TITLE
chore: refactor TimesheetTable to be data driven

### DIFF
--- a/src/utils/TimesheetTableData.test.tsx
+++ b/src/utils/TimesheetTableData.test.tsx
@@ -1,0 +1,119 @@
+import { cleanup, render, screen, within } from '@testing-library/react';
+import TimesheetDay from '../models/TimesheetDay';
+import { ValidationTypes } from '../validators/TimesheetDayValidator';
+import { build } from './TimesheetTableData';
+
+describe('build', () => {
+  test('given an empty list returns empty columns and rows', () => {
+    expect(build([], new Map())).toEqual({ columns: [], rows: [] });
+  });
+
+  test('returns the correct set of columns and rows', () => {
+    const timesheetDays = TimesheetDay.parse(`
+      20/12/2022
+      07:15-18:00
+
+      21/12/2022
+      07:10-15:45
+    `);
+
+    const { columns, rows } = build(
+      timesheetDays,
+      new Map([
+        [timesheetDays[1], new Set([ValidationTypes.UNORDERED_TIME_INTERVALS])],
+      ]),
+    );
+
+    expect(columns.length).toBe(4);
+    expect(columns[0].name).toBe('Day');
+    expect(columns[1].name).toBe('Entry 1');
+    expect(columns[2].name).toBe('Entry 2');
+    expect(columns[3].name).toBe('Total');
+
+    expect(rows.length).toBe(2);
+    expect(rows[0]).toEqual({
+      original: timesheetDays[0],
+      date: '20/12/2022',
+      entries: ['07:15', '18:00'],
+      totalDuration: '10h 45m',
+      validations: undefined,
+    });
+    expect(rows[1]).toEqual({
+      original: timesheetDays[1],
+      date: '21/12/2022',
+      entries: ['07:10', '15:45'],
+      totalDuration: '8h 35m',
+      validations: new Set([ValidationTypes.UNORDERED_TIME_INTERVALS]),
+    });
+  });
+
+  test('returns the correct cells for the columns', () => {
+    const timesheetDays = TimesheetDay.parse(`
+      20/12/2022
+      07:15-18:00
+
+      20/12/2022
+      07:15-18:00
+    `);
+    const { columns, rows } = build(
+      timesheetDays,
+      new Map([[timesheetDays[0], new Set([ValidationTypes.DUPLICATED_DATE])]]),
+    );
+    const getElement = () => screen.getByRole('cell');
+
+    render(<td>{columns[0].cell.render(rows[0])}</td>);
+    expect(getElement()).toHaveTextContent(/20\/12\/2022/);
+    expect(within(getElement()).getByRole('tooltip')).toBeInTheDocument();
+    cleanup();
+
+    render(<td>{columns[1].cell.render(rows[0])}</td>);
+    expect(getElement()).toHaveTextContent(/^07:15$/);
+    cleanup();
+
+    render(<td>{columns[2].cell.render(rows[0])}</td>);
+    expect(getElement()).toHaveTextContent(/^18:00$/);
+    cleanup();
+
+    render(<td>{columns[3].cell.render(rows[0])}</td>);
+    expect(getElement()).toHaveTextContent(/^10h 45m$/);
+    cleanup();
+  });
+
+  test('correctly deals with days with less entries than the maximum entries', () => {
+    const timesheetDays = TimesheetDay.parse(`
+      20/12/2022
+      07:15-12:00
+      13:00-18:00
+
+      21/12/2022
+      07:15-18:00
+    `);
+    const { columns, rows } = build(timesheetDays, new Map());
+    const getElement = () => screen.getByRole('cell');
+
+    render(<td>{columns[0].cell.render(rows[1])}</td>);
+    expect(getElement()).toHaveTextContent(/21\/12\/2022/);
+    expect(within(getElement()).queryByRole('tooltip')).not.toBeInTheDocument();
+    cleanup();
+
+    render(<td>{columns[1].cell.render(rows[1])}</td>);
+    expect(getElement()).toHaveTextContent(/^07:15$/);
+    cleanup();
+
+    render(<td>{columns[2].cell.render(rows[1])}</td>);
+    expect(getElement()).toHaveTextContent(/^18:00$/);
+    cleanup();
+
+    render(<td>{columns[3].cell.render(rows[1])}</td>);
+    expect(getElement()).toHaveTextContent(/^-$/);
+    cleanup();
+
+    render(<td>{columns[4].cell.render(rows[1])}</td>);
+    expect(getElement()).toHaveTextContent(/^-$/);
+    cleanup();
+
+    render(<td>{columns[5].cell.render(rows[1])}</td>);
+    expect(getElement()).toHaveTextContent(/^10h 45m$/);
+    cleanup();
+  });
+});

--- a/src/utils/TimesheetTableData.tsx
+++ b/src/utils/TimesheetTableData.tsx
@@ -1,0 +1,97 @@
+import React from 'react';
+import ValidationsTooltip from '../components/ValidationsTooltip';
+import {
+  formatDay,
+  formatDuration,
+  formatHourOfDay,
+} from '../formatters/DateTime';
+import TimesheetDay from '../models/TimesheetDay';
+import {
+  ValidationMap,
+  ValidationTypes,
+} from '../validators/TimesheetDayValidator';
+
+export interface TableColumn {
+  name: string;
+  cell: {
+    render: (p: TimesheetRow) => React.ReactNode;
+  };
+}
+
+export interface TimesheetRow {
+  original: TimesheetDay;
+  date: string;
+  entries: string[];
+  totalDuration: string;
+  validations?: Set<ValidationTypes>;
+}
+
+export function build(
+  timesheetDays: TimesheetDay[],
+  validations: ValidationMap,
+): {
+  columns: TableColumn[];
+  rows: TimesheetRow[];
+} {
+  return {
+    columns: buildColumns(timesheetDays, validations),
+    rows: buildRows(timesheetDays, validations),
+  };
+}
+
+function buildColumns(
+  timesheetDays: TimesheetDay[],
+  validations: ValidationMap,
+): TableColumn[] {
+  if (!timesheetDays.length) return [];
+
+  const maxNumberOfEntries = Array.from({
+    length: Math.max(...timesheetDays.map((d) => d.intervalsAsEntries.length)),
+  });
+  const columns: TableColumn[] = [];
+
+  columns.push({
+    name: 'Day',
+    cell: {
+      render: ({ date, validations }) => {
+        return (
+          <div className="text-slate-50 flex font-normal items-center">
+            <span>{date}</span>
+            <span>
+              <ValidationsTooltip validations={validations} />
+            </span>
+          </div>
+        );
+      },
+    },
+  });
+
+  // push the "Entries" columns from 1 to n
+  maxNumberOfEntries.forEach((_, index) => {
+    columns.push({
+      name: `Entry ${index + 1}`,
+      cell: {
+        render: (d) => d.entries[index] ?? '-',
+      },
+    });
+  });
+
+  columns.push({ name: 'Total', cell: { render: (d) => d.totalDuration } });
+
+  return columns;
+}
+
+function buildRows(
+  timesheetDays: TimesheetDay[],
+  validations: ValidationMap,
+): TimesheetRow[] {
+  return timesheetDays.map((timesheetDay) => {
+    return {
+      original: timesheetDay,
+      date: formatDay(timesheetDay.date),
+      entries: timesheetDay.intervalsAsEntries.map((d) => formatHourOfDay(d)),
+      totalDuration: formatDuration(timesheetDay.totalDurationInMinutes),
+      validations: validations.get(timesheetDay),
+    };
+  });
+}

--- a/src/validators/TimesheetDayValidator.ts
+++ b/src/validators/TimesheetDayValidator.ts
@@ -5,13 +5,15 @@ export enum ValidationTypes {
   UNORDERED_TIME_INTERVALS,
 }
 
+export type ValidationMap = Map<TimesheetDay, Set<ValidationTypes>>;
+
 /**
  * Retrieves a map containing as keys TimesheetDay objects and as values a set
  * of issues (ValidationTypes).
  */
 export default function getValidations(
   timesheetDays: TimesheetDay[],
-): Map<TimesheetDay, Set<ValidationTypes>> {
+): ValidationMap {
   const validations = new Map<TimesheetDay, Set<ValidationTypes>>();
 
   // TODO: Investigate if there's a performance issue here regarding the multiple iterations


### PR DESCRIPTION
Extract logic from inside the component to a file called
TimesheetTableData which has a function that returns a set of columns
and rows that will be iterated over in the TimesheetTable.

Also started using `useMemo` hook for these computations (validations
and the table data).